### PR TITLE
Add automatic Service creation for sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ kubectl coco apply -f app.yaml --sidecar \
   --sidecar-san-dns=myapp.example.com
 ```
 
+**Note:** When `--sidecar` is enabled, a Kubernetes Service (ClusterIP type) is automatically created with the name `<app-name>-sidecar` to expose the sidecar's HTTPS port. You can convert it to NodePort or use it with an Ingress for external access.
+
 See [sidecar/README.md](sidecar/README.md) for detailed configuration and usage.
 
 ## Configuration File

--- a/pkg/sidecar/service.go
+++ b/pkg/sidecar/service.go
@@ -1,0 +1,61 @@
+// Package sidecar handles injection of the secure access sidecar container into manifests.
+package sidecar
+
+import (
+	"fmt"
+
+	"github.com/confidential-devhub/cococtl/pkg/config"
+	"github.com/confidential-devhub/cococtl/pkg/manifest"
+)
+
+// GenerateService creates a Kubernetes Service manifest for the sidecar.
+// The Service exposes the HTTPS port of the sidecar using the same labels
+// as the workload pods.
+// Returns nil map if sidecar is not enabled.
+func GenerateService(m *manifest.Manifest, cfg *config.CocoConfig, appName, namespace string) (map[string]interface{}, error) {
+	if !cfg.Sidecar.Enabled {
+		return make(map[string]interface{}), nil
+	}
+
+	// Get labels from the pod template to use as selectors
+	labels, err := m.GetPodLabels()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod labels: %w", err)
+	}
+
+	// If no labels found, create a default label
+	if len(labels) == 0 {
+		labels = map[string]interface{}{
+			"app": appName,
+		}
+	}
+
+	serviceName := fmt.Sprintf("%s-sidecar", appName)
+
+	service := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]interface{}{
+			"name":      serviceName,
+			"namespace": namespace,
+			"labels": map[string]interface{}{
+				"app":       appName,
+				"component": "coco-sidecar",
+			},
+		},
+		"spec": map[string]interface{}{
+			"type":     "ClusterIP",
+			"selector": labels,
+			"ports": []interface{}{
+				map[string]interface{}{
+					"name":       "https",
+					"port":       cfg.Sidecar.HTTPSPort,
+					"targetPort": cfg.Sidecar.HTTPSPort,
+					"protocol":   "TCP",
+				},
+			},
+		},
+	}
+
+	return service, nil
+}

--- a/pkg/sidecar/service_test.go
+++ b/pkg/sidecar/service_test.go
@@ -1,0 +1,220 @@
+package sidecar
+
+import (
+	"os"
+	"testing"
+
+	"github.com/confidential-devhub/cococtl/pkg/config"
+	"github.com/confidential-devhub/cococtl/pkg/manifest"
+)
+
+func TestGenerateService(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  string
+		cfg       *config.CocoConfig
+		appName   string
+		namespace string
+		checkFunc func(t *testing.T, service map[string]interface{})
+	}{
+		{
+			name: "deployment with labels",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        version: v1
+    spec:
+      containers:
+      - name: main
+        image: nginx:latest`,
+			cfg: &config.CocoConfig{
+				Sidecar: config.SidecarConfig{
+					Enabled:   true,
+					HTTPSPort: 8443,
+				},
+			},
+			appName:   "test-app",
+			namespace: "default",
+			checkFunc: func(t *testing.T, service map[string]interface{}) {
+				// Check metadata
+				metadata, ok := service["metadata"].(map[string]interface{})
+				if !ok {
+					t.Fatal("metadata not found")
+				}
+				if metadata["name"] != "test-app-sidecar" {
+					t.Errorf("Expected name 'test-app-sidecar', got %v", metadata["name"])
+				}
+				if metadata["namespace"] != "default" {
+					t.Errorf("Expected namespace 'default', got %v", metadata["namespace"])
+				}
+
+				// Check spec
+				spec, ok := service["spec"].(map[string]interface{})
+				if !ok {
+					t.Fatal("spec not found")
+				}
+
+				// Check type
+				if spec["type"] != "ClusterIP" {
+					t.Errorf("Expected type 'ClusterIP', got %v", spec["type"])
+				}
+
+				// Check selector (should match pod labels)
+				selector, ok := spec["selector"].(map[string]interface{})
+				if !ok {
+					t.Fatal("selector not found")
+				}
+				if selector["app"] != "test-app" {
+					t.Errorf("Expected selector app='test-app', got %v", selector["app"])
+				}
+				if selector["version"] != "v1" {
+					t.Errorf("Expected selector version='v1', got %v", selector["version"])
+				}
+
+				// Check ports
+				ports, ok := spec["ports"].([]interface{})
+				if !ok || len(ports) != 1 {
+					t.Fatalf("Expected 1 port, got %v", ports)
+				}
+
+				port, ok := ports[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("port is not a map")
+				}
+				if port["port"] != 8443 {
+					t.Errorf("Expected port 8443, got %v", port["port"])
+				}
+				if port["targetPort"] != 8443 {
+					t.Errorf("Expected targetPort 8443, got %v", port["targetPort"])
+				}
+				if port["name"] != "https" {
+					t.Errorf("Expected port name 'https', got %v", port["name"])
+				}
+			},
+		},
+		{
+			name: "pod without labels",
+			manifest: `apiVersion: v1
+kind: Pod
+metadata:
+  name: simple-pod
+  namespace: test
+spec:
+  containers:
+  - name: main
+    image: nginx:latest`,
+			cfg: &config.CocoConfig{
+				Sidecar: config.SidecarConfig{
+					Enabled:   true,
+					HTTPSPort: 9443,
+				},
+			},
+			appName:   "simple-pod",
+			namespace: "test",
+			checkFunc: func(t *testing.T, service map[string]interface{}) {
+				// Check metadata
+				metadata, ok := service["metadata"].(map[string]interface{})
+				if !ok {
+					t.Fatal("metadata not found")
+				}
+				if metadata["name"] != "simple-pod-sidecar" {
+					t.Errorf("Expected name 'simple-pod-sidecar', got %v", metadata["name"])
+				}
+
+				// Check spec
+				spec, ok := service["spec"].(map[string]interface{})
+				if !ok {
+					t.Fatal("spec not found")
+				}
+
+				// Check selector (should have default label)
+				selector, ok := spec["selector"].(map[string]interface{})
+				if !ok {
+					t.Fatal("selector not found")
+				}
+				if selector["app"] != "simple-pod" {
+					t.Errorf("Expected default selector app='simple-pod', got %v", selector["app"])
+				}
+
+				// Check ports
+				ports, ok := spec["ports"].([]interface{})
+				if !ok || len(ports) != 1 {
+					t.Fatalf("Expected 1 port, got %v", ports)
+				}
+
+				port, ok := ports[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("port is not a map")
+				}
+				if port["port"] != 9443 {
+					t.Errorf("Expected port 9443, got %v", port["port"])
+				}
+			},
+		},
+		{
+			name: "sidecar disabled",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: main
+        image: nginx:latest`,
+			cfg: &config.CocoConfig{
+				Sidecar: config.SidecarConfig{
+					Enabled: false,
+				},
+			},
+			appName:   "test-app",
+			namespace: "default",
+			checkFunc: func(t *testing.T, service map[string]interface{}) {
+				// Should return empty map when disabled
+				if len(service) != 0 {
+					t.Errorf("Expected empty service map when sidecar disabled, got %v", service)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary manifest file
+			tmpFile := t.TempDir() + "/manifest.yaml"
+			if err := os.WriteFile(tmpFile, []byte(tt.manifest), 0600); err != nil {
+				t.Fatalf("Failed to create temp manifest: %v", err)
+			}
+
+			m, err := manifest.Load(tmpFile)
+			if err != nil {
+				t.Fatalf("Failed to load manifest: %v", err)
+			}
+
+			service, err := GenerateService(m, tt.cfg, tt.appName, tt.namespace)
+			if err != nil {
+				t.Fatalf("GenerateService() error = %v", err)
+			}
+
+			if service == nil {
+				t.Fatal("Expected service map (even if empty), got nil")
+			}
+
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, service)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the sidecar is enabled, a Kubernetes Service is automatically created and applied to expose the sidecar's HTTPS port. This improves user experience by eliminating the need to manually create a Service for every sidecar-enabled application.

The generated Service:
- Type: ClusterIP (can be converted to NodePort or used with Ingress)
- Name: <app-name>-sidecar
- Selector: Uses same labels as the workload pods
- Port: Matches the sidecar HTTPS port from config