### PR TITLE
trustee: replace kubectl exec with KBS admin HTTP API for attestation…

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -283,12 +283,16 @@ func handleTrusteeSetup(cmd *cobra.Command, cfg *config.CocoConfig, interactive,
 		ServiceName: "trustee-kbs",
 		KBSImage:    kbsImage,
 		PCCSURL:     cfg.PCCSURL,
+		RESTConfig:  client.Config,
+		AuthDir:     cfg.KBSAuthDir, // may be empty or ~ prefix; Deploy resolves it
 	}
 
 	if err := trustee.Deploy(ctx, client.Clientset, trusteeCfg); err != nil {
 		return false, "", fmt.Errorf("failed to deploy Trustee: %w", err)
 	}
 
+	// Deploy wrote the resolved path back to trusteeCfg.AuthDir; persist it.
+	cfg.KBSAuthDir = trusteeCfg.AuthDir
 	cfg.TrusteeServer = trustee.GetServiceURL(namespace, "trustee-kbs")
 	fmt.Printf("Trustee deployed successfully\n")
 	fmt.Printf("Trustee URL: %s\n", cfg.TrusteeServer)

--- a/go.mod
+++ b/go.mod
@@ -20,13 +20,16 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -45,6 +47,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -53,6 +57,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ type CocoConfig struct {
 	InitContainerCmd   string            `toml:"init_container_cmd" comment:"Default init container command (optional, default: attestation check)"`
 	KBSImage           string            `toml:"kbs_image" comment:"KBS all-in-one image for Trustee deployment (optional, default: ghcr.io/confidential-containers/key-broker-service:built-in-as-v0.17.0)"`
 	PCCSURL            string            `toml:"pccs_url" comment:"PCCS URL for SGX attestation (optional, default: https://api.trustedservices.intel.com/sgx/certification/v4/)"`
+	KBSAuthDir         string            `toml:"kbs_auth_dir" comment:"Directory containing KBS admin keys for 'kbs populate'; set automatically during init (default: ~/.kube/coco-kbs-auth)"`
 	ContainerPolicyURI string            `toml:"container_policy_uri" comment:"Container policy URI (optional)"`
 	RegistryCredURI    string            `toml:"registry_cred_uri" comment:"Container registry credentials URI (optional)"`
 	RegistryConfigURI  string            `toml:"registry_config_uri" comment:"Container registry config URI (optional)"`

--- a/pkg/trustee/kbs.go
+++ b/pkg/trustee/kbs.go
@@ -3,15 +3,23 @@ package trustee
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
+
+// errWatchClosed is returned by watchUntilReady when the API server closes the
+// watch channel normally (e.g. server-side timeout).  The caller should
+// re-list and re-watch rather than treating this as a terminal error.
+var errWatchClosed = errors.New("watch channel closed")
 
 const kbsRepositoryPath = "/opt/confidential-containers/kbs/repository"
 
@@ -51,7 +59,7 @@ func UploadResources(ctx context.Context, clientset kubernetes.Interface, namesp
 // GetKBSPodName retrieves the name of the KBS pod in the specified namespace.
 func GetKBSPodName(ctx context.Context, clientset kubernetes.Interface, namespace string) (string, error) {
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "app=kbs",
+		LabelSelector: trusteeLabel,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods: %w", err)
@@ -64,24 +72,116 @@ func GetKBSPodName(ctx context.Context, clientset kubernetes.Interface, namespac
 	return pods.Items[0].Name, nil
 }
 
-// WaitForKBSReady waits for the KBS pod to be ready.
+// WaitForKBSReady waits for a KBS pod to reach the Ready condition using the
+// Kubernetes watch API.  It re-lists and re-watches if the API server closes
+// the watch channel normally.  The caller is responsible for setting a deadline
+// on ctx if a hard timeout is required.
 func WaitForKBSReady(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
-	podName, err := GetKBSPodName(ctx, clientset, namespace)
-	if err != nil {
-		return err
-	}
+	for {
+		// List to get the current resource version and short-circuit if a pod
+		// is already ready.
+		pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: trusteeLabel,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list KBS pods: %w", err)
+		}
 
-	// #nosec G204 - namespace is from function parameter, podName is from kubectl get output
-	cmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=ready", "--timeout=120s",
-		"-n", namespace, fmt.Sprintf("pod/%s", podName))
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("pod not ready: %w\n%s", err, output)
-	}
+		for i := range pods.Items {
+			if isPodReady(&pods.Items[i]) {
+				return nil
+			}
+		}
 
-	return nil
+		// Watch from the resource version returned by List to avoid
+		// re-processing events already reflected in the List response.
+		watcher, err := clientset.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
+			LabelSelector:   trusteeLabel,
+			ResourceVersion: pods.ResourceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to watch KBS pods: %w", err)
+		}
+
+		err = watchUntilReady(ctx, watcher.ResultChan())
+		watcher.Stop()
+
+		if err == nil {
+			return nil // a pod became ready
+		}
+		if !errors.Is(err, errWatchClosed) {
+			return err // context cancelled/deadline, or Error event
+		}
+		// Watch channel closed normally (server-side timeout, connection reset,
+		// etc.) — re-list and re-watch.
+	}
 }
 
-// It uploads multiple secrets to KBS via kubectl cp.
+// watchUntilReady drains ch until a ready pod is observed, the context is
+// done, an Error event arrives, or the channel closes.  It returns nil on
+// success, errWatchClosed if the channel closes normally, and a descriptive
+// error otherwise.
+func watchUntilReady(ctx context.Context, ch <-chan k8swatch.Event) error {
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("timed out waiting for KBS pod to be ready: %w", ctx.Err())
+			}
+			return fmt.Errorf("cancelled waiting for KBS pod to be ready: %w", ctx.Err())
+		case event, ok := <-ch:
+			if !ok {
+				return errWatchClosed
+			}
+			switch event.Type {
+			case k8swatch.Error:
+				if status, ok := event.Object.(*metav1.Status); ok {
+					return fmt.Errorf("error watching KBS pod: %s: %s", status.Reason, status.Message)
+				}
+				return fmt.Errorf("error event received while watching KBS pod")
+			case k8swatch.Deleted:
+				// Pod deleted during a rollout; a replacement will appear.
+				// Continue watching rather than failing.
+			case k8swatch.Added, k8swatch.Modified:
+				pod, ok := event.Object.(*corev1.Pod)
+				if ok && isPodReady(pod) {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+// getReadyKBSPodName returns the name of the first KBS pod that is currently
+// in the Ready state.  It is used after WaitForKBSReady to guarantee the
+// selected pod is still ready, guarding against rollouts where GetKBSPodName
+// might pick a Terminating pod.
+func getReadyKBSPodName(ctx context.Context, clientset kubernetes.Interface, namespace string) (string, error) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: trusteeLabel,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list KBS pods: %w", err)
+	}
+	for i := range pods.Items {
+		if isPodReady(&pods.Items[i]) {
+			return pods.Items[i].Name, nil
+		}
+	}
+	return "", fmt.Errorf("no ready KBS pod found in namespace %s", namespace)
+}
+
+// isPodReady returns true if the pod's Ready condition is True.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// populateSecrets uploads multiple secrets to KBS via kubectl cp.
 func populateSecrets(ctx context.Context, clientset kubernetes.Interface, namespace string, secrets []SecretResource) error {
 	if len(secrets) == 0 {
 		return nil
@@ -92,7 +192,9 @@ func populateSecrets(ctx context.Context, clientset kubernetes.Interface, namesp
 		return err
 	}
 
-	if err := WaitForKBSReady(ctx, clientset, namespace); err != nil {
+	waitCtx, waitCancel := context.WithTimeout(ctx, kbsReadyTimeout)
+	defer waitCancel()
+	if err := WaitForKBSReady(waitCtx, clientset, namespace); err != nil {
 		return err
 	}
 

--- a/pkg/trustee/kbs_test.go
+++ b/pkg/trustee/kbs_test.go
@@ -6,8 +6,37 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+// readyPod returns a pod with the Ready condition set to True.
+func readyPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "kbs"},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// notReadyPod returns a pod with no Ready condition.
+func notReadyPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "kbs"},
+		},
+	}
+}
 
 func TestGetKBSPodName_Found(t *testing.T) {
 	// Setup fake clientset with KBS pod
@@ -89,5 +118,137 @@ func TestGetKBSPodName_MultiplePods(t *testing.T) {
 	expectedName := "kbs-pod-1"
 	if podName != expectedName {
 		t.Errorf("GetKBSPodName() = %v, want %v (first pod)", podName, expectedName)
+	}
+}
+
+// --- isPodReady tests ---
+
+func TestIsPodReady_Ready(t *testing.T) {
+	if !isPodReady(readyPod("p", "ns")) {
+		t.Error("isPodReady() = false for a pod with Ready=True, want true")
+	}
+}
+
+func TestIsPodReady_NotReady(t *testing.T) {
+	if isPodReady(notReadyPod("p", "ns")) {
+		t.Error("isPodReady() = true for a pod with no Ready condition, want false")
+	}
+}
+
+func TestIsPodReady_ConditionFalse(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+	if isPodReady(pod) {
+		t.Error("isPodReady() = true for a pod with Ready=False, want false")
+	}
+}
+
+// --- WaitForKBSReady tests ---
+
+func TestWaitForKBSReady_AlreadyReady(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(readyPod("kbs-pod", "trustee-ns"))
+
+	ctx := context.Background()
+	if err := WaitForKBSReady(ctx, fakeClient, "trustee-ns"); err != nil {
+		t.Fatalf("WaitForKBSReady() error = %v, want nil", err)
+	}
+}
+
+func TestWaitForKBSReady_NoPods(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so the watch returns right away
+
+	err := WaitForKBSReady(ctx, fakeClient, "trustee-ns")
+	if err == nil {
+		t.Fatal("WaitForKBSReady() error = nil, want context-cancelled error")
+	}
+}
+
+func TestWaitForKBSReady_ContextCancelled(t *testing.T) {
+	// Pod exists but is not ready.
+	fakeClient := fake.NewSimpleClientset(notReadyPod("kbs-pod", "trustee-ns"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before calling so watch exits immediately
+
+	err := WaitForKBSReady(ctx, fakeClient, "trustee-ns")
+	if err == nil {
+		t.Fatal("WaitForKBSReady() error = nil, want context-cancelled error")
+	}
+}
+
+func TestWaitForKBSReady_BecomesReady(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(notReadyPod("kbs-pod", "trustee-ns"))
+
+	fw := k8swatch.NewFake()
+	fakeClient.PrependWatchReactor("pods", func(_ k8stesting.Action) (bool, k8swatch.Interface, error) {
+		return true, fw, nil
+	})
+
+	// Inject a Modified event carrying a ready pod after the watch is consumed.
+	go fw.Modify(readyPod("kbs-pod", "trustee-ns"))
+
+	if err := WaitForKBSReady(context.Background(), fakeClient, "trustee-ns"); err != nil {
+		t.Fatalf("WaitForKBSReady() error = %v, want nil", err)
+	}
+}
+
+func TestWaitForKBSReady_DeletedThenReady(t *testing.T) {
+	// A Deleted event must not abort the wait; a subsequent Modified with a
+	// ready pod should succeed.
+	fakeClient := fake.NewSimpleClientset(notReadyPod("kbs-pod", "trustee-ns"))
+
+	fw := k8swatch.NewFake()
+	fakeClient.PrependWatchReactor("pods", func(_ k8stesting.Action) (bool, k8swatch.Interface, error) {
+		return true, fw, nil
+	})
+
+	go func() {
+		fw.Delete(notReadyPod("kbs-pod", "trustee-ns"))
+		fw.Modify(readyPod("kbs-pod-2", "trustee-ns"))
+	}()
+
+	if err := WaitForKBSReady(context.Background(), fakeClient, "trustee-ns"); err != nil {
+		t.Fatalf("WaitForKBSReady() error = %v, want nil (Deleted should be ignored)", err)
+	}
+}
+
+func TestWaitForKBSReady_WatchClosedRelists(t *testing.T) {
+	// When the watch channel closes normally, WaitForKBSReady must re-list.
+	// Set up: first watch closes immediately; the re-list finds the pod ready.
+	fakeClient := fake.NewSimpleClientset(notReadyPod("kbs-pod", "trustee-ns"))
+
+	fw := k8swatch.NewFake()
+	watchEstablished := make(chan struct{}, 1)
+	fakeClient.PrependWatchReactor("pods", func(_ k8stesting.Action) (bool, k8swatch.Interface, error) {
+		select {
+		case watchEstablished <- struct{}{}:
+		default:
+		}
+		return true, fw, nil
+	})
+
+	go func() {
+		<-watchEstablished
+		// Update the pod to ready in the tracker so the re-list finds it ready.
+		if err := fakeClient.Tracker().Update(
+			corev1.SchemeGroupVersion.WithResource("pods"),
+			readyPod("kbs-pod", "trustee-ns"),
+			"trustee-ns",
+		); err != nil {
+			return
+		}
+		fw.Stop() // close the watch channel, triggering re-list
+	}()
+
+	if err := WaitForKBSReady(context.Background(), fakeClient, "trustee-ns"); err != nil {
+		t.Fatalf("WaitForKBSReady() error = %v, want nil after re-list", err)
 	}
 }

--- a/pkg/trustee/trustee.go
+++ b/pkg/trustee/trustee.go
@@ -4,29 +4,49 @@ package trustee
 import (
 	"context"
 	"crypto/ed25519"
+	"errors"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"github.com/confidential-devhub/cococtl/pkg/kbsclient"
 )
 
 const (
 	trusteeLabel = "app=kbs"
 
-	// Default attestation status secret path and content
-	// This is used by the default init container to check attestation status
-	defaultAttestationStatusPath    = "/opt/confidential-containers/kbs/repository/default/attestation-status/status"
+	// defaultAttestationStatusContent is uploaded to KBS during deploy so the
+	// init container can verify attestation succeeded.
 	defaultAttestationStatusContent = "success"
+
+	// defaultKBSPort is the port the KBS pod listens on.
+	defaultKBSPort = 8080
+
+	// kbsReadyTimeout is the maximum time Deploy waits for the KBS pod to
+	// become Ready before giving up.
+	kbsReadyTimeout = 2 * time.Minute
+
+	// kbsAdminTimeout bounds the port-forward handshake and the subsequent
+	// SetResource HTTP call so a network hang cannot block Deploy indefinitely.
+	kbsAdminTimeout = 30 * time.Second
 )
 
 // DockerConfig represents the new .dockerconfigjson format
@@ -47,6 +67,14 @@ type Config struct {
 	KBSImage    string
 	PCCSURL     string
 	Secrets     []SecretResource
+
+	// RESTConfig is required for port-forwarding to the KBS pod during Deploy.
+	RESTConfig *rest.Config
+
+	// AuthDir is the directory where the generated KBS admin private key is
+	// persisted for later use by 'kbs populate'.  If empty, defaults to
+	// ~/.kube/coco-kbs-auth (resolved via DefaultAuthDir).
+	AuthDir string
 }
 
 // SecretResource represents a secret to be stored in KBS
@@ -74,13 +102,29 @@ func IsDeployed(ctx context.Context, clientset kubernetes.Interface, namespace s
 	return len(deployments.Items) > 0, nil
 }
 
-// Deploy deploys Trustee all-in-one KBS to the specified namespace
+// Deploy deploys Trustee all-in-one KBS to the specified namespace.
+// cfg.RESTConfig must be set; it is used to port-forward to the KBS pod
+// so that the admin HTTP API can be called without requiring an externally
+// reachable service URL.
 func Deploy(ctx context.Context, clientset kubernetes.Interface, cfg *Config) error {
+	if cfg.RESTConfig == nil {
+		return fmt.Errorf("cfg.RESTConfig is required for KBS deployment")
+	}
+
+	// Resolve the auth directory once and write it back so the caller can read
+	// the concrete path without calling DefaultAuthDir themselves.
+	authDir, err := DefaultAuthDir(cfg.AuthDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve auth directory: %w", err)
+	}
+	cfg.AuthDir = authDir
+
 	if err := ensureNamespace(ctx, clientset, cfg.Namespace); err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	if err := createAuthSecretFromKeys(ctx, cfg.Namespace); err != nil {
+	privateKey, err := createAuthSecretFromKeys(ctx, cfg.Namespace, authDir)
+	if err != nil {
 		return fmt.Errorf("failed to create auth secret: %w", err)
 	}
 
@@ -88,7 +132,6 @@ func Deploy(ctx context.Context, clientset kubernetes.Interface, cfg *Config) er
 		return fmt.Errorf("failed to deploy ConfigMaps: %w", err)
 	}
 
-	// Deploy PCCS ConfigMap if PCCSURL is configured
 	if cfg.PCCSURL != "" {
 		if err := deployPCCSConfigMap(ctx, cfg.Namespace, cfg.PCCSURL); err != nil {
 			return fmt.Errorf("failed to deploy PCCS ConfigMap: %w", err)
@@ -99,9 +142,41 @@ func Deploy(ctx context.Context, clientset kubernetes.Interface, cfg *Config) er
 		return fmt.Errorf("failed to deploy KBS: %w", err)
 	}
 
-	// Create default attestation status secret for init container
-	if err := createDefaultAttestationStatus(cfg.Namespace); err != nil {
-		return fmt.Errorf("failed to create default attestation status: %w", err)
+	// Wait for the KBS pod to be ready, bounded by kbsReadyTimeout.
+	waitCtx, waitCancel := context.WithTimeout(ctx, kbsReadyTimeout)
+	defer waitCancel()
+	if err := WaitForKBSReady(waitCtx, clientset, cfg.Namespace); err != nil {
+		return fmt.Errorf("KBS pod not ready: %w", err)
+	}
+
+	// Select an explicitly ready pod to port-forward to, guarding against
+	// rollouts where a Terminating pod might be listed first.
+	podName, err := getReadyKBSPodName(waitCtx, clientset, cfg.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to find ready KBS pod: %w", err)
+	}
+
+	// Both the port-forward handshake and the SetResource HTTP call share a
+	// single bounded context.  30 s is sufficient for both operations together.
+	adminCtx, adminCancel := context.WithTimeout(ctx, kbsAdminTimeout)
+	defer adminCancel()
+
+	localPort, stopForward, err := portForwardKBSPod(adminCtx, cfg.RESTConfig, clientset, cfg.Namespace, podName)
+	if err != nil {
+		return fmt.Errorf("failed to port-forward to KBS pod: %w", err)
+	}
+	defer stopForward()
+
+	kbsURL := fmt.Sprintf("http://127.0.0.1:%d", localPort)
+	kbsClient, err := kbsclient.New(kbsURL, privateKey, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create KBS client: %w", err)
+	}
+
+	// Upload the default attestation status via the KBS admin HTTP API.
+	// This replaces the former kubectl exec approach.
+	if err := kbsClient.SetResource(adminCtx, "default/attestation-status/status", []byte(defaultAttestationStatusContent)); err != nil {
+		return fmt.Errorf("failed to set default attestation status: %w", err)
 	}
 
 	if len(cfg.Secrets) > 0 {
@@ -115,7 +190,87 @@ func Deploy(ctx context.Context, clientset kubernetes.Interface, cfg *Config) er
 
 // GetServiceURL returns the URL of the deployed Trustee KBS service
 func GetServiceURL(namespace, serviceName string) string {
-	return fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", serviceName, namespace)
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", serviceName, namespace, defaultKBSPort)
+}
+
+// DefaultAuthDir returns the resolved, cleaned KBS auth directory.
+// If override is empty it defaults to ~/.kube/coco-kbs-auth.
+// A leading ~ in override is expanded to the user's home directory.
+func DefaultAuthDir(override string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	if override == "" {
+		return filepath.Join(home, ".kube", "coco-kbs-auth"), nil
+	}
+	// Expand a leading ~ so callers can pass "~/custom-dir" safely.
+	// TrimPrefix strips the leading "~/" leaving a relative segment that
+	// filepath.Join correctly appends under home (override[1:] would leave
+	// a leading "/" that silently drops the home prefix).
+	if override == "~" {
+		override = home
+	} else if strings.HasPrefix(override, "~/") {
+		override = filepath.Join(home, strings.TrimPrefix(override, "~/"))
+	}
+	return filepath.Clean(override), nil
+}
+
+// portForwardKBSPod opens a port-forward from a random local port to port
+// defaultKBSPort on the named pod.  It returns the local port number and a
+// stop function the caller must invoke when done.
+func portForwardKBSPod(ctx context.Context, restConfig *rest.Config, clientset kubernetes.Interface, namespace, podName string) (localPort uint16, stop func(), err error) {
+	url := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("portforward").
+		URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return 0, nil, fmt.Errorf("create port-forward transport: %w", err)
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, url)
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("0:%d", defaultKBSPort)}, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return 0, nil, fmt.Errorf("create port forwarder: %w", err)
+	}
+
+	forwardErr := make(chan error, 1)
+	go func() {
+		forwardErr <- fw.ForwardPorts()
+	}()
+
+	select {
+	case <-ctx.Done():
+		close(stopCh)
+		return 0, nil, fmt.Errorf("context cancelled before port-forward ready: %w", ctx.Err())
+	case fwErr := <-forwardErr:
+		return 0, nil, fmt.Errorf("port-forward failed to start: %w", fwErr)
+	case <-readyCh:
+		// forward is ready
+	}
+
+	ports, err := fw.GetPorts()
+	if err != nil {
+		close(stopCh)
+		return 0, nil, fmt.Errorf("get forwarded ports: %w", err)
+	}
+	if len(ports) == 0 {
+		close(stopCh)
+		return 0, nil, fmt.Errorf("port forwarder returned no ports")
+	}
+
+	var once sync.Once
+	stopFn := func() { once.Do(func() { close(stopCh) }) }
+
+	return ports[0].Local, stopFn, nil
 }
 
 func ensureNamespace(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
@@ -148,37 +303,39 @@ func applyManifest(ctx context.Context, yaml string) error {
 	return nil
 }
 
-func createAuthSecretFromKeys(ctx context.Context, namespace string) error {
-	// Generate ED25519 key pair locally
-	publicKey, privateKey, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		return fmt.Errorf("failed to generate key pair: %w", err)
+// createAuthSecretFromKeys loads or generates an Ed25519 private key, persists
+// it to authDir/private.key, creates a Kubernetes Secret containing only the
+// public key (for KBS JWT verification), and returns the private key so Deploy
+// can call the KBS admin API immediately.
+//
+// If a valid key already exists at authDir/private.key it is reused, making
+// the function idempotent across Deploy retries after partial failures.
+func createAuthSecretFromKeys(ctx context.Context, namespace, authDir string) (ed25519.PrivateKey, error) {
+	if err := os.MkdirAll(authDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create auth directory %s: %w", authDir, err)
 	}
 
-	// Encode private key to PKCS8 PEM format
-	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	privateKey, err := loadOrGeneratePrivateKey(filepath.Join(authDir, "private.key"))
 	if err != nil {
-		return fmt.Errorf("failed to marshal private key: %w", err)
+		return nil, err
 	}
-	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: privateKeyBytes,
-	})
 
-	// Encode public key to PKIX PEM format
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	// Derive the public key to put in the K8s Secret.
+	pubKey, ok := privateKey.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("unexpected public key type from Ed25519 private key")
+	}
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
-		return fmt.Errorf("failed to marshal public key: %w", err)
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
 	}
-	publicKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: publicKeyBytes,
-	})
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
 
-	// Create temporary directory for keys
+	// Write only the public key to a temporary directory for the secret.
+	// The private key must never be stored in the cluster.
 	tmpDir, err := os.MkdirTemp("", "trustee-keys-*")
 	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	defer func() {
 		if err := os.RemoveAll(tmpDir); err != nil {
@@ -186,32 +343,108 @@ func createAuthSecretFromKeys(ctx context.Context, namespace string) error {
 		}
 	}()
 
-	// Write keys to temporary files
-	privateKeyPath := filepath.Join(tmpDir, "private.key")
-	publicKeyPath := filepath.Join(tmpDir, "public.pub")
-
-	if err := os.WriteFile(privateKeyPath, privateKeyPEM, 0600); err != nil {
-		return fmt.Errorf("failed to write private key: %w", err)
+	tmpPubPath := filepath.Join(tmpDir, "public.pub")
+	if err := os.WriteFile(tmpPubPath, publicKeyPEM, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write public key to temp dir: %w", err)
 	}
 
-	if err := os.WriteFile(publicKeyPath, publicKeyPEM, 0600); err != nil {
-		return fmt.Errorf("failed to write public key: %w", err)
-	}
-
-	// Create secret from files
-	// #nosec G204 - namespace is from function parameter (application-controlled), paths are from os.MkdirTemp
-	cmd := exec.Command("kubectl", "create", "secret", "generic",
+	// #nosec G204 - namespace is from function parameter (application-controlled), path is from os.MkdirTemp
+	cmd := exec.CommandContext(ctx, "kubectl", "create", "secret", "generic",
 		"kbs-auth-public-key", "-n", namespace,
-		fmt.Sprintf("--from-file=%s", publicKeyPath),
-		fmt.Sprintf("--from-file=%s", privateKeyPath),
+		fmt.Sprintf("--from-file=%s", tmpPubPath),
 		"--dry-run=client", "-o", "yaml")
 	secretYAML, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to create secret YAML: %w\n%s", err, secretYAML)
+		return nil, fmt.Errorf("failed to create secret YAML: %w\n%s", err, secretYAML)
 	}
 
-	// Apply the secret
-	return applyManifest(ctx, string(secretYAML))
+	if err := applyManifest(ctx, string(secretYAML)); err != nil {
+		return nil, err
+	}
+
+	return privateKey, nil
+}
+
+// loadOrGeneratePrivateKey returns the Ed25519 private key at keyPath.
+// If the file already exists it is parsed and returned — enabling Deploy to be
+// retried after a partial failure without manual cleanup.
+// If the file does not exist a new key pair is generated and persisted
+// atomically (temp-file + rename) so a partial write never corrupts an
+// existing key.
+// Any file-system error other than ErrNotExist is returned immediately.
+func loadOrGeneratePrivateKey(keyPath string) (ed25519.PrivateKey, error) {
+	// #nosec G304 -- keyPath is constructed from the user-controlled authDir, resolved and cleaned by DefaultAuthDir
+	pemData, readErr := os.ReadFile(keyPath)
+	if readErr == nil {
+		// File exists — check permissions before using it.
+		// A world- or group-readable private key is a credential leak.
+		info, err := os.Stat(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat existing key at %s: %w", keyPath, err)
+		}
+		if info.Mode().Perm()&0077 != 0 {
+			return nil, fmt.Errorf("existing key at %s has overly permissive mode %04o; group/other permissions must not be set", keyPath, info.Mode().Perm())
+		}
+
+		// Parse and return the existing key.
+		block, _ := pem.Decode(pemData)
+		if block == nil {
+			return nil, fmt.Errorf("existing key at %s is not valid PEM", keyPath)
+		}
+		raw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse existing key at %s: %w", keyPath, err)
+		}
+		key, ok := raw.(ed25519.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("existing key at %s is not an Ed25519 private key (got %T)", keyPath, raw)
+		}
+		return key, nil
+	}
+	if !errors.Is(readErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to read key at %s: %w", keyPath, readErr)
+	}
+
+	// File does not exist — generate a new key and persist it.
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+
+	// Write via temp file in the same directory, then rename for atomicity.
+	tmpKey, err := os.CreateTemp(filepath.Dir(keyPath), ".private.key.*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to stage private key: %w", err)
+	}
+	staged := true
+	defer func() {
+		if staged {
+			_ = os.Remove(tmpKey.Name())
+		}
+	}()
+	if err := tmpKey.Chmod(0600); err != nil {
+		_ = tmpKey.Close()
+		return nil, fmt.Errorf("failed to set key file permissions: %w", err)
+	}
+	if _, err := tmpKey.Write(privateKeyPEM); err != nil {
+		_ = tmpKey.Close()
+		return nil, fmt.Errorf("failed to write private key: %w", err)
+	}
+	if err := tmpKey.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close staged key file: %w", err)
+	}
+	if err := os.Rename(tmpKey.Name(), keyPath); err != nil {
+		return nil, fmt.Errorf("failed to install private key at %s: %w", keyPath, err)
+	}
+	staged = false
+
+	return privateKey, nil
 }
 
 func buildConfigMapsManifest(namespace string) string {
@@ -224,7 +457,7 @@ metadata:
 data:
   kbs-config.toml: |
     [http_server]
-    sockets = ["0.0.0.0:8080"]
+    sockets = ["0.0.0.0:%d"]
     insecure_http = true
 
     [attestation_token]
@@ -273,7 +506,7 @@ metadata:
 data:
   reference-values.json: |
     {}
-`, namespace, namespace, namespace)
+`, namespace, defaultKBSPort, namespace, namespace)
 }
 
 func deployConfigMaps(ctx context.Context, namespace string) error {
@@ -372,7 +605,7 @@ spec:
         - --config-file
         - /etc/kbs-config/kbs-config.toml
         ports:
-        - containerPort: 8080
+        - containerPort: %d
           name: kbs
           protocol: TCP
         securityContext:
@@ -402,10 +635,10 @@ spec:
   selector:
     app: kbs
   ports:
-  - port: 8080
-    targetPort: 8080
+  - port: %d
+    targetPort: %d
     protocol: TCP
-`, cfg.Namespace, cfg.KBSImage, volumeMounts, volumes, cfg.ServiceName, cfg.Namespace)
+`, cfg.Namespace, cfg.KBSImage, defaultKBSPort, volumeMounts, volumes, cfg.ServiceName, cfg.Namespace, defaultKBSPort, defaultKBSPort)
 }
 
 func deployKBS(ctx context.Context, cfg *Config) error {
@@ -540,7 +773,7 @@ func AddK8sSecretToTrustee(trusteeNamespace, secretName, secretNamespace string)
 	// Get the KBS pod name
 	// #nosec G204 -- namespace/secret names are from trusted config, not user input
 	cmd := exec.Command("kubectl", "get", "pod", "-n", trusteeNamespace,
-		"-l", "app=kbs", "-o", "jsonpath={.items[0].metadata.name}")
+		"-l", trusteeLabel, "-o", "jsonpath={.items[0].metadata.name}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to get KBS pod: %w\n%s", err, output)
@@ -657,49 +890,3 @@ func AddImagePullSecretToTrustee(trusteeNamespace, secretName, secretNamespace s
 	return AddK8sSecretToTrustee(trusteeNamespace, secretName, secretNamespace)
 }
 
-// createDefaultAttestationStatus creates a default attestation-status secret in Trustee
-// This is used by the default init container command to check attestation status
-func createDefaultAttestationStatus(namespace string) error {
-	// Get the KBS pod name
-	// #nosec G204 -- namespace is from trusted config, not user input
-	cmd := exec.Command("kubectl", "get", "pod", "-n", namespace,
-		"-l", "app=kbs", "-o", "jsonpath={.items[0].metadata.name}")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get KBS pod: %w\n%s", err, output)
-	}
-	podName := strings.TrimSpace(string(output))
-
-	if podName == "" {
-		return fmt.Errorf("no KBS pod found in namespace %s", namespace)
-	}
-
-	// Wait for pod to be ready
-	// #nosec G204 - namespace is from function parameter, podName is from kubectl get output
-	cmd = exec.Command("kubectl", "wait", "--for=condition=ready", "--timeout=120s",
-		"-n", namespace, fmt.Sprintf("pod/%s", podName))
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("pod not ready: %w\n%s", err, output)
-	}
-
-	// Create the directory structure and file using kubectl exec
-	// Path: /opt/confidential-containers/kbs/repository/default/attestation-status/status
-	mkdirCmd := "mkdir -p /opt/confidential-containers/kbs/repository/default/attestation-status"
-	// #nosec G204 - namespace is from function parameter, podName is from kubectl get, mkdirCmd is a constant string
-	cmd = exec.Command("kubectl", "exec", "-n", namespace, podName, "--", "sh", "-c", mkdirCmd)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to create directory in KBS pod: %w\n%s", err, output)
-	}
-
-	// Write the content to the file
-	writeCmd := fmt.Sprintf("echo -n '%s' > %s", defaultAttestationStatusContent, defaultAttestationStatusPath)
-	// #nosec G204 - namespace is from function parameter, podName is from kubectl get, writeCmd uses constants
-	cmd = exec.Command("kubectl", "exec", "-n", namespace, podName, "--", "sh", "-c", writeCmd)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to write attestation status file: %w\n%s", err, output)
-	}
-
-	return nil
-}


### PR DESCRIPTION
… status

createDefaultAttestationStatus used kubectl get/wait/exec to write the default/attestation-status/status resource directly into the KBS pod filesystem.  This was fragile (requires kubectl binary, exec privileges, and manual directory creation inside the container) and bypassed the KBS API entirely.

This commit replaces that approach with the KBS admin HTTP API:

- createAuthSecretFromKeys now returns the generated ed25519.PrivateKey and persists the PKCS8 PEM to ~/.kube/coco-kbs-auth/private.key (or cfg.AuthDir) for later use by 'kbs populate'.
- Deploy() resolves the auth directory, threads the private key into a kbsclient.Client, and calls SetResource to upload the attestation status.  A client-go port-forward bridges the in-cluster KBS port to a random localhost port so the HTTP API is reachable from outside the cluster without requiring an externally exposed service.
- WaitForKBSReady replaces the kubectl wait shell-out with the Kubernetes watch API (List then Watch from the returned ResourceVersion), handling Added/Modified/Deleted/Error event types explicitly.
- portForwardKBSPod and DefaultAuthDir are new internal helpers.
- createDefaultAttestationStatus is deleted.
- Config gains RESTConfig (*rest.Config) and AuthDir string fields.
- CocoConfig gains KBSAuthDir (persisted to ~/.kube/coco-config.toml).
- cmd/init.go passes client.Config and sets cfg.KBSAuthDir after deploy.

New tests: TestIsPodReady_{Ready,NotReady,ConditionFalse}, TestWaitForKBSReady_{AlreadyReady,NoPods,ContextCancelled}.