### PR TITLE
trustee: remove all kubectl cp usage and dead code

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -289,7 +289,7 @@ func transformManifest(ctx context.Context, m *manifest.Manifest, cfg *config.Co
 
 	// 2. Convert secrets if enabled
 	if convertSecrets {
-		if err := handleSecrets(ctx, m, cfg, skipApply, clientset, clientErr); err != nil {
+		if err := handleSecrets(ctx, m, skipApply, clientset, clientErr); err != nil {
 			return fmt.Errorf("failed to convert secrets: %w", err)
 		}
 	} else {
@@ -306,7 +306,7 @@ func transformManifest(ctx context.Context, m *manifest.Manifest, cfg *config.Co
 	var imagePullSecretsInfo []initdata.ImagePullSecretInfo
 	if convertSecrets {
 		var err error
-		imagePullSecretsInfo, err = handleImagePullSecrets(ctx, m, cfg, skipApply, clientset, clientErr)
+		imagePullSecretsInfo, err = handleImagePullSecrets(ctx, m, skipApply, clientset, clientErr)
 		if err != nil {
 			return fmt.Errorf("failed to handle imagePullSecrets: %w", err)
 		}
@@ -348,7 +348,7 @@ func transformManifest(ctx context.Context, m *manifest.Manifest, cfg *config.Co
 
 		// Generate and upload server certificate (or save to file in skip-apply mode)
 		fmt.Println("  - Setting up sidecar server certificate")
-		if err := handleSidecarServerCert(ctx, cfg, appName, namespace, trusteeNamespace, skipApply, manifestFile, clientset, clientErr); err != nil {
+		if err := handleSidecarServerCert(ctx, cfg, appName, namespace, trusteeNamespace, skipApply, manifestFile, client); err != nil {
 			return fmt.Errorf("failed to setup sidecar server certificate: %w", err)
 		}
 
@@ -427,7 +427,7 @@ func handleInitContainer(m *manifest.Manifest, cfg *config.CocoConfig) error {
 	return nil
 }
 
-func handleSecrets(ctx context.Context, m *manifest.Manifest, cfg *config.CocoConfig, skipApply bool, clientset kubernetes.Interface, clientErr error) error {
+func handleSecrets(ctx context.Context, m *manifest.Manifest, skipApply bool, clientset kubernetes.Interface, clientErr error) error {
 	// 1. Detect all secret references
 	allSecretRefs, err := secrets.DetectSecrets(m.GetData())
 	if err != nil {
@@ -542,24 +542,7 @@ func handleSecrets(ctx context.Context, m *manifest.Manifest, cfg *config.CocoCo
 		return err
 	}
 
-	// 6. Add secrets to Trustee KBS repository (only if not skipping apply)
-	// FIXME: Use proper Trustee apis/CLI to add the secrets
-	autoUploadSuccess := false
-	if !skipApply {
-		trusteeNamespace := cfg.GetTrusteeNamespace()
-		fmt.Println("  - Adding secrets to Trustee KBS repository")
-		if err := addSecretsToTrustee(secretRefs, trusteeNamespace); err != nil {
-			fmt.Printf("  ⚠ Warning: Failed to add secrets to Trustee: %v\n", err)
-			fmt.Println("    You will need to add secrets manually")
-		} else {
-			fmt.Printf("  ✓ Successfully added %d secret(s) to Trustee\n", len(secretRefs))
-			autoUploadSuccess = true
-		}
-	} else {
-		fmt.Println("  - Skipping Trustee upload (--skip-apply mode)")
-	}
-
-	// 7. Generate Trustee configuration
+	// 6. Generate Trustee secrets file (directly consumable by 'kbs populate -f')
 	ext := filepath.Ext(m.GetName())
 	if ext == "" {
 		ext = ".yaml"
@@ -571,8 +554,8 @@ func handleSecrets(ctx context.Context, m *manifest.Manifest, cfg *config.CocoCo
 		return fmt.Errorf("failed to generate Trustee config: %w", err)
 	}
 
-	// 8. Print instructions
-	secrets.PrintTrusteeInstructions(allSealedSecrets, trusteeConfigPath, autoUploadSuccess)
+	// 7. Print instructions pointing to kbs populate
+	secrets.PrintTrusteeInstructions(allSealedSecrets, trusteeConfigPath)
 
 	return nil
 }
@@ -603,36 +586,11 @@ func applyWithKubectl(ctx context.Context, manifestPath string) error {
 	return nil
 }
 
-// addSecretsToTrustee adds all K8s secrets to the Trustee KBS repository
-// This is a temporary solution until proper CLI tooling is available
-func addSecretsToTrustee(secretRefs []secrets.SecretReference, trusteeNamespace string) error {
-	// Import the trustee package function
-	for _, ref := range secretRefs {
-		// Determine the namespace for the secret
-		// If the secret reference has a namespace, use it
-		// Otherwise, use the current namespace
-		secretNamespace := ref.Namespace
-		if secretNamespace == "" {
-			var err error
-			secretNamespace, err = k8s.GetCurrentNamespace()
-			if err != nil {
-				return fmt.Errorf("failed to get current namespace for secret %s: %w", ref.Name, err)
-			}
-		}
-
-		// Add the secret to Trustee
-		if err := trustee.AddK8sSecretToTrustee(trusteeNamespace, ref.Name, secretNamespace); err != nil {
-			return fmt.Errorf("failed to add secret %s: %w", ref.Name, err)
-		}
-	}
-
-	return nil
-}
-
-// handleImagePullSecrets processes imagePullSecrets from the manifest
-// It detects, uploads to KBS, and prepares them for initdata
-// Falls back to default service account if no imagePullSecrets in manifest
-func handleImagePullSecrets(ctx context.Context, m *manifest.Manifest, cfg *config.CocoConfig, skipApply bool, clientset kubernetes.Interface, clientErr error) ([]initdata.ImagePullSecretInfo, error) {
+// handleImagePullSecrets detects imagePullSecrets from the manifest, inspects their
+// keys from the cluster, and returns ImagePullSecretInfo for initdata generation.
+// Falls back to the default service account if no imagePullSecrets are in the manifest.
+// Uploading secrets to KBS is not done here; use 'cococtl kbs populate' instead.
+func handleImagePullSecrets(ctx context.Context, m *manifest.Manifest, skipApply bool, clientset kubernetes.Interface, clientErr error) ([]initdata.ImagePullSecretInfo, error) {
 	// Detect imagePullSecrets in manifest, with fallback to default service account
 	// Pass clientset for SA fallback (nil if client creation failed — fallback is skipped)
 	imagePullSecretRefs, err := secrets.DetectImagePullSecretsWithServiceAccount(ctx, clientset, m.GetData())
@@ -701,45 +659,11 @@ func handleImagePullSecrets(ctx context.Context, m *manifest.Manifest, cfg *conf
 		}
 	}
 
-	// Upload imagePullSecrets to Trustee KBS (if not skipApply)
-	if !skipApply {
-		trusteeNamespace := cfg.GetTrusteeNamespace()
-		fmt.Println("  - Adding imagePullSecrets to Trustee KBS repository")
-		if err := addImagePullSecretsToTrustee(imagePullSecretRefs, trusteeNamespace); err != nil {
-			fmt.Printf("  ⚠ Warning: Failed to add imagePullSecrets to Trustee: %v\n", err)
-			fmt.Println("    You will need to add imagePullSecrets manually")
-		} else {
-			fmt.Printf("  ✓ Successfully added %d imagePullSecret(s) to Trustee\n", len(imagePullSecretRefs))
-		}
-	}
-
 	// Note: We keep imagePullSecrets in the manifest as CRI-O still needs them for image pulls.
 	// The authenticated_registry_credentials_uri in initdata is used by guest components.
+	// Use 'cococtl kbs populate -f <trustee-secrets.yaml>' to upload imagePullSecrets to KBS.
 
 	return imagePullSecretsInfo, nil
-}
-
-// addImagePullSecretsToTrustee adds all imagePullSecrets to the Trustee KBS repository
-// This is a temporary solution until proper CLI tooling is available
-func addImagePullSecretsToTrustee(secretRefs []secrets.SecretReference, trusteeNamespace string) error {
-	for _, ref := range secretRefs {
-		// Determine the namespace for the secret
-		secretNamespace := ref.Namespace
-		if secretNamespace == "" {
-			var err error
-			secretNamespace, err = k8s.GetCurrentNamespace()
-			if err != nil {
-				return fmt.Errorf("failed to get current namespace for imagePullSecret %s: %w", ref.Name, err)
-			}
-		}
-
-		// Add the imagePullSecret to Trustee
-		if err := trustee.AddImagePullSecretToTrustee(trusteeNamespace, ref.Name, secretNamespace); err != nil {
-			return fmt.Errorf("failed to add imagePullSecret %s: %w", ref.Name, err)
-		}
-	}
-
-	return nil
 }
 
 // handleSidecarServerCert generates and uploads a server certificate for the sidecar.
@@ -753,7 +677,8 @@ func addImagePullSecretsToTrustee(secretRefs []secrets.SecretReference, trusteeN
 //   - trusteeNamespace: namespace where Trustee KBS is deployed
 //   - skipApply: when true, save certs to file instead of uploading to Trustee
 //   - manifestPath: path to the original manifest file (for cert file naming)
-func handleSidecarServerCert(ctx context.Context, cfg *config.CocoConfig, appName, namespace, trusteeNamespace string, skipApply bool, manifestPath string, clientset kubernetes.Interface, clientErr error) error {
+//   - k8sClient: Kubernetes client (nil when client creation failed)
+func handleSidecarServerCert(ctx context.Context, cfg *config.CocoConfig, appName, namespace, trusteeNamespace string, skipApply bool, manifestPath string, k8sClient *k8s.Client) error {
 	// Load Client CA
 	certDir := cfg.Sidecar.CertDir
 	caCertPath := filepath.Join(certDir, "ca-cert.pem")
@@ -793,10 +718,10 @@ func handleSidecarServerCert(ctx context.Context, cfg *config.CocoConfig, appNam
 	// Auto-detect SANs unless skipped
 	if !sidecarSkipAutoSANs {
 		// Auto-detect node IPs
-		if clientErr != nil {
-			fmt.Printf("Warning: failed to create Kubernetes client for node IP detection: %v\n", clientErr)
+		if k8sClient == nil {
+			fmt.Println("Warning: Kubernetes client unavailable for node IP auto-detection")
 		} else {
-			nodeIPs, err := cluster.GetNodeIPs(ctx, clientset)
+			nodeIPs, err := cluster.GetNodeIPs(ctx, k8sClient.Clientset)
 			if err != nil {
 				fmt.Printf("Warning: failed to auto-detect node IPs: %v\n", err)
 			} else {
@@ -832,16 +757,21 @@ func handleSidecarServerCert(ctx context.Context, cfg *config.CocoConfig, appNam
 	serverKeyPath := namespace + "/sidecar-tls-" + appName + "/server-key"
 
 	if !skipApply {
-		// Normal mode: upload to Trustee KBS
-		if clientErr != nil {
-			return fmt.Errorf("failed to create Kubernetes client for certificate upload: %w", clientErr)
+		// Normal mode: upload to Trustee KBS via port-forward
+		if k8sClient == nil {
+			return fmt.Errorf("kubernetes client is required for certificate upload to KBS")
 		}
 		fmt.Printf("  - Uploading server certificate to Trustee KBS (namespace: %s)...\n", trusteeNamespace)
+		kbsClient, stopForward, err := trustee.NewClientWithPortForward(ctx, k8sClient.Config, k8sClient.Clientset, trusteeNamespace, cfg.KBSAuthDir)
+		if err != nil {
+			return fmt.Errorf("failed to connect to KBS: %w", err)
+		}
+		defer stopForward()
 		resources := map[string][]byte{
 			serverCertPath: serverCert.CertPEM,
 			serverKeyPath:  serverCert.KeyPEM,
 		}
-		if err := trustee.UploadResources(ctx, clientset, trusteeNamespace, resources); err != nil {
+		if err := trustee.UploadResources(ctx, kbsClient, resources); err != nil {
 			return fmt.Errorf("failed to upload server certificate to KBS: %w", err)
 		}
 		fmt.Printf("  - Server certificate uploaded to kbs:///%s and kbs:///%s\n", serverCertPath, serverKeyPath)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -324,20 +324,24 @@ func handleSidecarCertSetup(ctx context.Context, cfg *config.CocoConfig, trustee
 
 	var clientCAPath string
 	if cfg.TrusteeServer != "" && uploadClientCA {
-		sidecarClient, sidecarClientErr := k8s.NewClient(k8s.ClientOptions{})
+		sidecarK8sClient, sidecarClientErr := k8s.NewClient(k8s.ClientOptions{})
 		if sidecarClientErr != nil {
 			return fmt.Errorf("failed to create Kubernetes client for sidecar cert setup: %w", sidecarClientErr)
 		}
 
-		// Upload Client CA to Trustee KBS
+		// Upload Client CA to Trustee KBS via port-forward.
 		// Note: We always use "default" namespace in the KBS path for consistency,
 		// regardless of where Trustee is deployed. This ensures all apps reference
 		// the same client CA location.
 		const kbsResourceNamespace = "default"
 		fmt.Printf("  - Uploading Client CA to Trustee KBS (Trustee namespace: %s, resource path: default)...\n", trusteeNamespace)
 		clientCAPath = kbsResourceNamespace + "/sidecar-tls/client-ca"
-		clientset := sidecarClient.Clientset
-		if err := trustee.UploadResource(ctx, clientset, trusteeNamespace, clientCAPath, clientCA.CertPEM); err != nil {
+		kbsClient, stopForward, err := trustee.NewClientWithPortForward(ctx, sidecarK8sClient.Config, sidecarK8sClient.Clientset, trusteeNamespace, cfg.KBSAuthDir)
+		if err != nil {
+			return fmt.Errorf("failed to connect to KBS: %w", err)
+		}
+		defer stopForward()
+		if err := trustee.UploadResource(ctx, kbsClient, clientCAPath, clientCA.CertPEM); err != nil {
 			return fmt.Errorf("failed to upload client CA to KBS: %w", err)
 		}
 	} else {

--- a/pkg/secrets/output.go
+++ b/pkg/secrets/output.go
@@ -57,9 +57,8 @@ func GenerateTrusteeConfig(sealedSecrets []*SealedSecretData, outputPath string)
 	return nil
 }
 
-// PrintTrusteeInstructions prints console instructions for setting up Trustee
-// autoUploadSuccess indicates whether secrets were automatically uploaded to Trustee
-func PrintTrusteeInstructions(sealedSecrets []*SealedSecretData, configPath string, autoUploadSuccess bool) {
+// PrintTrusteeInstructions prints console instructions for uploading secrets to Trustee KBS.
+func PrintTrusteeInstructions(sealedSecrets []*SealedSecretData, configPath string) {
 	if len(sealedSecrets) == 0 {
 		return
 	}
@@ -67,15 +66,7 @@ func PrintTrusteeInstructions(sealedSecrets []*SealedSecretData, configPath stri
 	fmt.Println()
 	fmt.Println("Trustee KBS Configuration")
 	fmt.Println("═════════════════════════════════════════════════════════")
-
-	if autoUploadSuccess {
-		fmt.Printf("✓ Successfully added %d secret(s) to Trustee KBS\n\n", len(sealedSecrets))
-		fmt.Println("The following sealed secrets are configured:")
-	} else {
-		fmt.Printf("The following %d sealed secret(s) need to be added to your Trustee KBS:\n\n", len(sealedSecrets))
-	}
-
-	fmt.Println()
+	fmt.Printf("The following %d sealed secret(s) must be uploaded to your Trustee KBS:\n\n", len(sealedSecrets))
 
 	for i, sealed := range sealedSecrets {
 		fmt.Printf("%d. %s\n", i+1, sealed.ResourceURI)
@@ -97,17 +88,10 @@ func PrintTrusteeInstructions(sealedSecrets []*SealedSecretData, configPath stri
 		fmt.Println()
 	}
 
-	fmt.Printf("Full configuration saved to: %s\n", configPath)
+	fmt.Printf("Secrets file: %s\n", configPath)
 	fmt.Println()
-
-	if autoUploadSuccess {
-		fmt.Println("Note: Secrets have been automatically uploaded to Trustee KBS.")
-		fmt.Println("      The configuration file above is saved for your reference.")
-	} else {
-		fmt.Println("Note: Automatic Trustee upload failed or was skipped.")
-		fmt.Println("      Please manually configure these secrets in your Trustee KBS")
-		fmt.Println("      using the configuration file above.")
-	}
+	fmt.Printf("Upload to KBS:\n")
+	fmt.Printf("  cococtl kbs populate -f %s\n", configPath)
 	fmt.Println()
 }
 

--- a/pkg/trustee/kbs.go
+++ b/pkg/trustee/kbs.go
@@ -2,18 +2,18 @@ package trustee
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/confidential-devhub/cococtl/pkg/kbsclient"
 )
 
 // errWatchClosed is returned by watchUntilReady when the API server closes the
@@ -21,39 +21,76 @@ import (
 // re-list and re-watch rather than treating this as a terminal error.
 var errWatchClosed = errors.New("watch channel closed")
 
-const kbsRepositoryPath = "/opt/confidential-containers/kbs/repository"
-
-// UploadResource uploads a single resource to Trustee KBS.
+// UploadResource uploads a single resource to Trustee KBS via the KBS admin HTTP API.
 // The resourcePath should be relative (e.g., "default/sidecar-tls/server-cert").
 // The data is the raw bytes to upload.
-func UploadResource(ctx context.Context, clientset kubernetes.Interface, namespace, resourcePath string, data []byte) error {
-	resources := []SecretResource{
-		{
-			URI:  "kbs:///" + resourcePath,
-			Data: data,
-		},
-	}
-
-	return populateSecrets(ctx, clientset, namespace, resources)
+func UploadResource(ctx context.Context, client *kbsclient.Client, resourcePath string, data []byte) error {
+	return client.SetResource(ctx, resourcePath, data)
 }
 
-// UploadResources uploads multiple resources to Trustee KBS in a single operation.
+// UploadResources uploads multiple resources to Trustee KBS via the KBS admin HTTP API.
 // Each resource is specified as a map entry where key is the resource path
 // (e.g., "default/sidecar-tls/server-cert") and value is the data bytes.
-func UploadResources(ctx context.Context, clientset kubernetes.Interface, namespace string, resources map[string][]byte) error {
-	if len(resources) == 0 {
-		return nil
-	}
-
-	secretResources := make([]SecretResource, 0, len(resources))
+func UploadResources(ctx context.Context, client *kbsclient.Client, resources map[string][]byte) error {
 	for path, data := range resources {
-		secretResources = append(secretResources, SecretResource{
-			URI:  "kbs:///" + path,
-			Data: data,
-		})
+		if err := client.SetResource(ctx, path, data); err != nil {
+			return fmt.Errorf("upload %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// NewClientWithPortForward creates a kbsclient.Client connected to the KBS pod via a
+// temporary port-forward. The caller must invoke the returned stop function when done
+// to release the port-forward. ctx bounds only the port-forward handshake; subsequent
+// HTTP calls use the kbsclient's own per-request timeout.
+//
+// authDir is the directory containing private.key (the Ed25519 key written during init).
+// If empty, DefaultAuthDir is used.
+func NewClientWithPortForward(ctx context.Context, restConfig *rest.Config, clientset kubernetes.Interface, namespace, authDir string) (*kbsclient.Client, func(), error) {
+	resolvedAuthDir, err := DefaultAuthDir(authDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve auth directory: %w", err)
 	}
 
-	return populateSecrets(ctx, clientset, namespace, secretResources)
+	// Wait for a KBS pod to be ready before attempting the port-forward.
+	// Bound by kbsReadyTimeout so the caller does not need to set a deadline.
+	waitCtx, waitCancel := context.WithTimeout(ctx, kbsReadyTimeout)
+	defer waitCancel()
+	if err := WaitForKBSReady(waitCtx, clientset, namespace); err != nil {
+		return nil, nil, fmt.Errorf("KBS pod not ready: %w", err)
+	}
+
+	podName, err := getReadyKBSPodName(waitCtx, clientset, namespace)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find ready KBS pod: %w", err)
+	}
+
+	// Port-forward; the context only bounds the handshake, not the forward lifetime.
+	portFwdCtx, portFwdCancel := context.WithTimeout(ctx, kbsAdminTimeout)
+	localPort, stopForward, err := portForwardKBSPod(portFwdCtx, restConfig, clientset, namespace, podName)
+	portFwdCancel()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to port-forward to KBS pod: %w", err)
+	}
+
+	// Load the Ed25519 private key written by Deploy/init.
+	keyPath := filepath.Join(resolvedAuthDir, "private.key")
+	// #nosec G304 -- keyPath is constructed from DefaultAuthDir, an application-controlled path
+	pemData, err := os.ReadFile(keyPath)
+	if err != nil {
+		stopForward()
+		return nil, nil, fmt.Errorf("failed to read KBS private key from %s (run 'cococtl init' first): %w", keyPath, err)
+	}
+
+	kbsURL := fmt.Sprintf("http://127.0.0.1:%d", localPort)
+	kbsClient, err := kbsclient.NewFromPEM(kbsURL, pemData, nil)
+	if err != nil {
+		stopForward()
+		return nil, nil, fmt.Errorf("failed to create KBS client: %w", err)
+	}
+
+	return kbsClient, stopForward, nil
 }
 
 // GetKBSPodName retrieves the name of the KBS pod in the specified namespace.
@@ -181,198 +218,3 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// populateSecrets uploads multiple secrets to KBS via kubectl cp.
-func populateSecrets(ctx context.Context, clientset kubernetes.Interface, namespace string, secrets []SecretResource) error {
-	if len(secrets) == 0 {
-		return nil
-	}
-
-	podName, err := GetKBSPodName(ctx, clientset, namespace)
-	if err != nil {
-		return err
-	}
-
-	waitCtx, waitCancel := context.WithTimeout(ctx, kbsReadyTimeout)
-	defer waitCancel()
-	if err := WaitForKBSReady(waitCtx, clientset, namespace); err != nil {
-		return err
-	}
-
-	// Use empty prefix for unpredictable temp directory name (more secure)
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
-	}
-
-	// Ensure secure cleanup even on panic or error
-	defer func() {
-		if err := secureDeleteDir(tmpDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to securely delete temp directory %s: %v\n", tmpDir, err)
-		}
-	}()
-
-	for _, secret := range secrets {
-		resourcePath := strings.TrimPrefix(secret.URI, "kbs://")
-		resourcePath = strings.TrimPrefix(resourcePath, "/")
-
-		fullPath := filepath.Join(tmpDir, resourcePath)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0700); err != nil {
-			return fmt.Errorf("failed to create directory: %w", err)
-		}
-
-		// Write with strict permissions
-		if err := writeSecretFile(fullPath, secret.Data); err != nil {
-			return fmt.Errorf("failed to write secret: %w", err)
-		}
-	}
-
-	// #nosec G204 - namespace is from function parameter, tmpDir is from os.MkdirTemp, podName is from kubectl get
-	// Use --no-preserve to avoid tar ownership errors when local files have different uid/gid than container
-	cmd := exec.CommandContext(ctx, "kubectl", "cp", "--no-preserve=true", "-n", namespace,
-		tmpDir+"/.", podName+":"+kbsRepositoryPath+"/")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to copy secrets to KBS: %w\n%s", err, output)
-	}
-
-	return nil
-}
-
-// writeSecretFile writes secret data with strict permissions, bypassing umask.
-func writeSecretFile(path string, data []byte) error {
-	// #nosec G304 -- Path is constructed from KBS resource URI and tmpDir (both controlled)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := f.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close file %s: %v\n", path, closeErr)
-		}
-	}()
-
-	if _, err := f.Write(data); err != nil {
-		return err
-	}
-
-	// Explicitly set permissions to ensure 0600 regardless of umask
-	return f.Chmod(0600)
-}
-
-// secureDeleteDir securely deletes a directory by overwriting all files before removal.
-// This prevents forensic recovery of sensitive cryptographic material.
-func secureDeleteDir(dir string) error {
-	// Walk directory and overwrite all regular files
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Only overwrite regular files, not directories or symlinks
-		if info.Mode().IsRegular() {
-			if err := secureDeleteFile(path, info.Size()); err != nil {
-				// Log but continue - best effort deletion
-				fmt.Fprintf(os.Stderr, "Warning: failed to securely delete %s: %v\n", path, err)
-			}
-		}
-		return nil
-	})
-
-	if err != nil {
-		// Continue with removal even if overwrite failed
-		fmt.Fprintf(os.Stderr, "Warning: errors during secure deletion: %v\n", err)
-	}
-
-	// Remove the directory after overwriting files
-	return os.RemoveAll(dir)
-}
-
-// secureDeleteFile overwrites a file with random data before deletion.
-// Performs 3-pass overwrite: random, zeros, random
-func secureDeleteFile(path string, size int64) error {
-	if size == 0 {
-		return nil // Empty file, nothing to overwrite
-	}
-
-	// #nosec G304 -- Path comes from filepath.Walk in secureDeleteDir, validated as regular file
-	f, err := os.OpenFile(path, os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := f.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close file %s: %v\n", path, closeErr)
-		}
-	}()
-
-	// Allocate buffer for overwriting (max 1MB chunks for large files)
-	bufSize := int64(1024 * 1024)
-	if size < bufSize {
-		bufSize = size
-	}
-	buf := make([]byte, bufSize)
-
-	// Pass 1: Random data
-	for written := int64(0); written < size; {
-		toWrite := bufSize
-		if size-written < bufSize {
-			toWrite = size - written
-		}
-		// Fill buffer with cryptographically secure random data
-		if _, err := rand.Read(buf[:toWrite]); err != nil {
-			return fmt.Errorf("pass 1 random generation failed: %w", err)
-		}
-		if _, err := f.Write(buf[:toWrite]); err != nil {
-			return fmt.Errorf("pass 1 write failed: %w", err)
-		}
-		written += toWrite
-	}
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("pass 1 sync failed: %w", err)
-	}
-
-	// Pass 2: Zeros
-	if _, err := f.Seek(0, 0); err != nil {
-		return fmt.Errorf("seek before pass 2 failed: %w", err)
-	}
-	for i := range buf {
-		buf[i] = 0
-	}
-	for written := int64(0); written < size; {
-		toWrite := bufSize
-		if size-written < bufSize {
-			toWrite = size - written
-		}
-		if _, err := f.Write(buf[:toWrite]); err != nil {
-			return fmt.Errorf("pass 2 write failed: %w", err)
-		}
-		written += toWrite
-	}
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("pass 2 sync failed: %w", err)
-	}
-
-	// Pass 3: Random data again
-	if _, err := f.Seek(0, 0); err != nil {
-		return fmt.Errorf("seek before pass 3 failed: %w", err)
-	}
-	for written := int64(0); written < size; {
-		toWrite := bufSize
-		if size-written < bufSize {
-			toWrite = size - written
-		}
-		// Fill buffer with cryptographically secure random data
-		if _, err := rand.Read(buf[:toWrite]); err != nil {
-			return fmt.Errorf("pass 3 random generation failed: %w", err)
-		}
-		if _, err := f.Write(buf[:toWrite]); err != nil {
-			return fmt.Errorf("pass 3 write failed: %w", err)
-		}
-		written += toWrite
-	}
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("pass 3 sync failed: %w", err)
-	}
-
-	return nil
-}

--- a/pkg/trustee/trustee.go
+++ b/pkg/trustee/trustee.go
@@ -156,12 +156,11 @@ func Deploy(ctx context.Context, clientset kubernetes.Interface, cfg *Config) er
 		return fmt.Errorf("failed to find ready KBS pod: %w", err)
 	}
 
-	// Both the port-forward handshake and the SetResource HTTP call share a
-	// single bounded context.  30 s is sufficient for both operations together.
-	adminCtx, adminCancel := context.WithTimeout(ctx, kbsAdminTimeout)
-	defer adminCancel()
-
-	localPort, stopForward, err := portForwardKBSPod(adminCtx, cfg.RESTConfig, clientset, cfg.Namespace, podName)
+	// portFwdCtx bounds only the port-forward handshake. All subsequent HTTP calls
+	// use ctx directly with the kbsclient's own per-request timeout.
+	portFwdCtx, portFwdCancel := context.WithTimeout(ctx, kbsAdminTimeout)
+	localPort, stopForward, err := portForwardKBSPod(portFwdCtx, cfg.RESTConfig, clientset, cfg.Namespace, podName)
+	portFwdCancel()
 	if err != nil {
 		return fmt.Errorf("failed to port-forward to KBS pod: %w", err)
 	}
@@ -175,13 +174,16 @@ func Deploy(ctx context.Context, clientset kubernetes.Interface, cfg *Config) er
 
 	// Upload the default attestation status via the KBS admin HTTP API.
 	// This replaces the former kubectl exec approach.
-	if err := kbsClient.SetResource(adminCtx, "default/attestation-status/status", []byte(defaultAttestationStatusContent)); err != nil {
+	if err := kbsClient.SetResource(ctx, "default/attestation-status/status", []byte(defaultAttestationStatusContent)); err != nil {
 		return fmt.Errorf("failed to set default attestation status: %w", err)
 	}
 
-	if len(cfg.Secrets) > 0 {
-		if err := populateSecrets(ctx, clientset, cfg.Namespace, cfg.Secrets); err != nil {
-			return fmt.Errorf("failed to populate secrets: %w", err)
+	// Upload any initial secrets using the same port-forward connection.
+	for _, secret := range cfg.Secrets {
+		// Strip "kbs://" and any leading slash to get the bare resource path.
+		resourcePath := strings.TrimPrefix(strings.TrimPrefix(secret.URI, "kbs://"), "/")
+		if err := kbsClient.SetResource(ctx, resourcePath, secret.Data); err != nil {
+			return fmt.Errorf("failed to upload secret %s: %w", secret.URI, err)
 		}
 	}
 
@@ -754,139 +756,4 @@ func ConvertDockercfgToDockerConfigJSON(dockercfgData []byte) ([]byte, error) {
 	return newData, nil
 }
 
-// AddK8sSecretToTrustee adds a Kubernetes secret to the Trustee KBS repository
-// This is a temporary solution until proper CLI tooling is available
-//
-// The secret data is stored in the KBS repository with the following structure:
-// /opt/confidential-containers/kbs/repository/{namespace}/{secret-name}/{key}
-//
-// Key name transformations (via GetKBSKeyName):
-//   - .dockercfg secrets are converted to .dockerconfigjson format (data conversion)
-//     and stored with key name "dockerconfigjson" (leading dot stripped)
-//   - .dockerconfigjson secrets are stored with key name "dockerconfigjson" (leading dot stripped)
-//   - Other keys with leading dots have the dot stripped for KBS URI compatibility
-//
-// For example, a secret named "reg-cred" with key ".dockercfg" in namespace "coco"
-// will have its data converted to .dockerconfigjson format and be stored at:
-// /opt/confidential-containers/kbs/repository/coco/reg-cred/dockerconfigjson
-func AddK8sSecretToTrustee(trusteeNamespace, secretName, secretNamespace string) error {
-	// Get the KBS pod name
-	// #nosec G204 -- namespace/secret names are from trusted config, not user input
-	cmd := exec.Command("kubectl", "get", "pod", "-n", trusteeNamespace,
-		"-l", trusteeLabel, "-o", "jsonpath={.items[0].metadata.name}")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get KBS pod: %w\n%s", err, output)
-	}
-	podName := strings.TrimSpace(string(output))
-
-	if podName == "" {
-		return fmt.Errorf("no KBS pod found in namespace %s", trusteeNamespace)
-	}
-
-	// Wait for pod to be ready
-	// #nosec G204 - trusteeNamespace is from function parameter, podName is from kubectl get output
-	cmd = exec.Command("kubectl", "wait", "--for=condition=ready", "--timeout=30s",
-		"-n", trusteeNamespace, fmt.Sprintf("pod/%s", podName))
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("pod not ready: %w\n%s", err, output)
-	}
-
-	// Get the secret data from Kubernetes
-	// #nosec G204 -- namespace/secret names are from trusted config, not user input
-	cmd = exec.Command("kubectl", "get", "secret", secretName, "-n", secretNamespace,
-		"-o", "jsonpath={.data}")
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get secret %s in namespace %s: %w\n%s", secretName, secretNamespace, err, output)
-	}
-
-	// Parse the secret data
-	var secretData map[string]string
-	if err := json.Unmarshal(output, &secretData); err != nil {
-		return fmt.Errorf("failed to parse secret data: %w", err)
-	}
-
-	if len(secretData) == 0 {
-		return fmt.Errorf("secret %s has no data", secretName)
-	}
-
-	// Create a temporary directory to prepare the secret files
-	tmpDir, err := os.MkdirTemp("", "kbs-secret-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove temp directory %s: %v\n", tmpDir, err)
-		}
-	}()
-
-	// Create the directory structure: {tmpDir}/{secretNamespace}/{secretName}/
-	secretDir := filepath.Join(tmpDir, secretNamespace, secretName)
-	if err := os.MkdirAll(secretDir, 0750); err != nil {
-		return fmt.Errorf("failed to create secret directory: %w", err)
-	}
-
-	// Write each key-value pair as a file
-	for key, encodedValue := range secretData {
-		// Decode the base64-encoded value
-		decodedValue, err := base64.StdEncoding.DecodeString(encodedValue)
-		if err != nil {
-			return fmt.Errorf("failed to decode secret value for key %s: %w", key, err)
-		}
-
-		// Check if this is a .dockercfg secret and convert to .dockerconfigjson format
-		// Trustee only handles dockerconfigjson format
-		if key == ".dockercfg" {
-			convertedValue, err := ConvertDockercfgToDockerConfigJSON(decodedValue)
-			if err != nil {
-				return fmt.Errorf("failed to convert .dockercfg to .dockerconfigjson: %w", err)
-			}
-			decodedValue = convertedValue
-		}
-
-		// Get the KBS key name using the centralized logic
-		// This handles both format conversion (.dockercfg -> .dockerconfigjson)
-		// and key name normalization (stripping leading dots)
-		kbsKey := GetKBSKeyName(key)
-
-		// Write the decoded value to a file
-		filePath := filepath.Join(secretDir, kbsKey)
-		if err := os.WriteFile(filePath, decodedValue, 0600); err != nil {
-			return fmt.Errorf("failed to write secret file for key %s: %w", kbsKey, err)
-		}
-	}
-
-	// Copy the entire directory structure to the KBS pod
-	// The structure will be: /opt/confidential-containers/kbs/repository/{secretNamespace}/{secretName}/{key}
-	srcPath := filepath.Join(tmpDir, secretNamespace) + "/."
-	destPath := fmt.Sprintf("%s:/opt/confidential-containers/kbs/repository/%s/", podName, secretNamespace)
-
-	// #nosec G204 - trusteeNamespace is from function parameter, srcPath uses os.MkdirTemp tmpDir, podName is from kubectl get
-	cmd = exec.Command("kubectl", "cp", "-n", trusteeNamespace, srcPath, destPath)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to copy secret to KBS pod: %w\n%s", err, output)
-	}
-
-	return nil
-}
-
-// AddImagePullSecretToTrustee adds an imagePullSecret to the Trustee KBS repository
-// This is a temporary solution until proper CLI tooling is available
-//
-// The secret data is stored in the KBS repository with the following structure:
-// /opt/confidential-containers/kbs/repository/{namespace}/{secret-name}/{key}
-//
-// Key name transformations are handled by AddK8sSecretToTrustee via GetKBSKeyName.
-// See AddK8sSecretToTrustee documentation for details on format conversions and key naming.
-//
-// This function is isolated for easy removal when proper tooling is available
-func AddImagePullSecretToTrustee(trusteeNamespace, secretName, secretNamespace string) error {
-	// Reuse the existing AddK8sSecretToTrustee function
-	// ImagePullSecrets are just regular K8s secrets, so the logic is the same
-	// All key name transformations are handled consistently via GetKBSKeyName
-	return AddK8sSecretToTrustee(trusteeNamespace, secretName, secretNamespace)
-}
 


### PR DESCRIPTION
kbs.go
- Add kbsReadyTimeout bound to WaitForKBSReady in NewClientWithPortForward, matching the guard that populateSecrets already had
- Remove dead populateSecrets, writeSecretFile, secureDeleteDir, secureDeleteFile and the now-orphaned kbsRepositoryPath constant
- Drop unused imports: crypto/rand, os/exec, strings

trustee.go
- Simplify secret URI stripping to a single TrimPrefix("kbs://") + TrimPrefix("/") instead of the fragile triple-TrimPrefix chain
- Remove AddK8sSecretToTrustee and AddImagePullSecretToTrustee (last kubectl cp callers in the package)

cmd/apply.go
- Remove addSecretsToTrustee, addImagePullSecretsToTrustee and their call sites; apply no longer uploads secrets to KBS automatically
- PrintTrusteeInstructions now takes no autoUploadSuccess flag and prints 'cococtl kbs populate -f <file>' as the next step

pkg/secrets/output.go
- Drop autoUploadSuccess parameter from PrintTrusteeInstructions; the function now always prints the kbs populate instruction