### PR TITLE
fix: detect and convert secrets in initContainers, not just containers

### DIFF
--- a/integration_test/secrets_test.go
+++ b/integration_test/secrets_test.go
@@ -271,12 +271,129 @@ func TestManifest_RemoveSecretVolume(t *testing.T) {
 	}
 }
 
+func TestManifest_ConvertEnvSecretToSealed_InitContainer(t *testing.T) {
+	m, err := manifest.Load("testdata/manifests/pod-with-initcontainer-secrets.yaml")
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	sealedSecret := "sealed.fakejwsheader.eyJ2ZXJzaW9uIjoiMC4xLjAifQ.fakesignature"
+
+	err = m.ConvertEnvSecretToSealed("init-setup", "INIT_SECRET", sealedSecret)
+	if err != nil {
+		t.Fatalf("ConvertEnvSecretToSealed() failed: %v", err)
+	}
+
+	spec, err := m.GetSpec()
+	if err != nil {
+		t.Fatalf("GetSpec() failed: %v", err)
+	}
+
+	initContainers, ok := spec["initContainers"].([]interface{})
+	if !ok || len(initContainers) == 0 {
+		t.Fatal("No initContainers found")
+	}
+
+	container, ok := initContainers[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("initContainer is not a map")
+	}
+
+	env, ok := container["env"].([]interface{})
+	if !ok || len(env) == 0 {
+		t.Fatal("No env variables found in initContainer")
+	}
+
+	found := false
+	for _, e := range env {
+		envVar, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if envVar["name"] == "INIT_SECRET" {
+			if _, hasValueFrom := envVar["valueFrom"]; hasValueFrom {
+				t.Error("valueFrom still exists after conversion")
+			}
+			value, ok := envVar["value"].(string)
+			if !ok {
+				t.Fatal("value is not a string")
+			}
+			if value != sealedSecret {
+				t.Errorf("value = %q, want %q", value, sealedSecret)
+			}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("INIT_SECRET env variable not found in initContainer")
+	}
+}
+
+func TestManifest_ReplaceSecretName_InitContainer(t *testing.T) {
+	m, err := manifest.Load("testdata/manifests/pod-with-initcontainer-secrets.yaml")
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	err = m.ReplaceSecretName("my-app-secret", "new-secret")
+	if err != nil {
+		t.Fatalf("ReplaceSecretName() failed: %v", err)
+	}
+
+	spec, err := m.GetSpec()
+	if err != nil {
+		t.Fatalf("GetSpec() failed: %v", err)
+	}
+
+	initContainers, ok := spec["initContainers"].([]interface{})
+	if !ok || len(initContainers) == 0 {
+		t.Fatal("No initContainers found")
+	}
+
+	container, ok := initContainers[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("initContainer is not a map")
+	}
+
+	env, ok := container["env"].([]interface{})
+	if !ok || len(env) == 0 {
+		t.Fatal("No env variables found in initContainer")
+	}
+
+	envVar, ok := env[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("env var is not a map")
+	}
+
+	valueFrom, ok := envVar["valueFrom"].(map[string]interface{})
+	if !ok {
+		t.Fatal("valueFrom is not a map")
+	}
+
+	secretKeyRef, ok := valueFrom["secretKeyRef"].(map[string]interface{})
+	if !ok {
+		t.Fatal("secretKeyRef is not a map")
+	}
+
+	name, _ := secretKeyRef["name"].(string)
+	if name != "new-secret" {
+		t.Errorf("secretKeyRef.name = %q, want %q", name, "new-secret")
+	}
+}
+
 func TestSecrets_DetectSecrets_IntegrationManifests(t *testing.T) {
 	tests := []struct {
 		name          string
 		manifestPath  string
 		expectedCount int
 	}{
+		{
+			name:          "env secrets in initContainers only",
+			manifestPath:  "testdata/manifests/pod-with-initcontainer-secrets.yaml",
+			expectedCount: 1, // my-app-secret
+		},
 		{
 			name:          "env secrets",
 			manifestPath:  "testdata/manifests/pod-with-env-secret.yaml",

--- a/integration_test/testdata/manifests/pod-with-initcontainer-secrets.yaml
+++ b/integration_test/testdata/manifests/pod-with-initcontainer-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-with-initcontainer-secrets
+  namespace: default
+spec:
+  initContainers:
+  - name: init-setup
+    image: busybox:latest
+    command: ["sh", "-c", "echo setup"]
+    env:
+    - name: INIT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: my-app-secret
+          key: secret-value
+  containers:
+  - name: app
+    image: nginx:latest

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -637,32 +637,34 @@ func (m *Manifest) ReplaceSecretName(oldName, newName string) error {
 		return err
 	}
 
-	// Replace in containers
-	if containers, ok := podSpec["containers"].([]interface{}); ok {
-		for _, container := range containers {
-			if c, ok := container.(map[string]interface{}); ok {
-				// Replace in env variables
-				if env, ok := c["env"].([]interface{}); ok {
-					for _, e := range env {
-						if envVar, ok := e.(map[string]interface{}); ok {
-							if valueFrom, ok := envVar["valueFrom"].(map[string]interface{}); ok {
-								if secretKeyRef, ok := valueFrom["secretKeyRef"].(map[string]interface{}); ok {
-									if name, ok := secretKeyRef["name"].(string); ok && name == oldName {
-										secretKeyRef["name"] = newName
+	// Replace in containers and initContainers
+	for _, containerKey := range []string{"containers", "initContainers"} {
+		if containers, ok := podSpec[containerKey].([]interface{}); ok {
+			for _, container := range containers {
+				if c, ok := container.(map[string]interface{}); ok {
+					// Replace in env variables
+					if env, ok := c["env"].([]interface{}); ok {
+						for _, e := range env {
+							if envVar, ok := e.(map[string]interface{}); ok {
+								if valueFrom, ok := envVar["valueFrom"].(map[string]interface{}); ok {
+									if secretKeyRef, ok := valueFrom["secretKeyRef"].(map[string]interface{}); ok {
+										if name, ok := secretKeyRef["name"].(string); ok && name == oldName {
+											secretKeyRef["name"] = newName
+										}
 									}
 								}
 							}
 						}
 					}
-				}
 
-				// Replace in envFrom
-				if envFrom, ok := c["envFrom"].([]interface{}); ok {
-					for _, ef := range envFrom {
-						if envFromItem, ok := ef.(map[string]interface{}); ok {
-							if secretRef, ok := envFromItem["secretRef"].(map[string]interface{}); ok {
-								if name, ok := secretRef["name"].(string); ok && name == oldName {
-									secretRef["name"] = newName
+					// Replace in envFrom
+					if envFrom, ok := c["envFrom"].([]interface{}); ok {
+						for _, ef := range envFrom {
+							if envFromItem, ok := ef.(map[string]interface{}); ok {
+								if secretRef, ok := envFromItem["secretRef"].(map[string]interface{}); ok {
+									if name, ok := secretRef["name"].(string); ok && name == oldName {
+										secretRef["name"] = newName
+									}
 								}
 							}
 						}
@@ -821,45 +823,43 @@ func (m *Manifest) ConvertEnvSecretToSealed(containerName, envVarName, sealedSec
 		return err
 	}
 
-	containers, ok := podSpec["containers"].([]interface{})
-	if !ok {
-		return fmt.Errorf("no containers found in spec")
-	}
-
-	// Find the container and env variable
-	for _, container := range containers {
-		c, ok := container.(map[string]interface{})
+	for _, containerKey := range []string{"containers", "initContainers"} {
+		containers, ok := podSpec[containerKey].([]interface{})
 		if !ok {
 			continue
 		}
 
-		// Check if this is the target container
-		name, _ := c["name"].(string)
-		if containerName != "" && name != containerName {
-			continue
-		}
-
-		// Find the env variable
-		env, ok := c["env"].([]interface{})
-		if !ok {
-			continue
-		}
-
-		for _, e := range env {
-			envVar, ok := e.(map[string]interface{})
+		for _, container := range containers {
+			c, ok := container.(map[string]interface{})
 			if !ok {
 				continue
 			}
 
-			envName, _ := envVar["name"].(string)
-			if envName != envVarName {
+			name, _ := c["name"].(string)
+			if containerName != "" && name != containerName {
 				continue
 			}
 
-			// Replace secretKeyRef with value
-			delete(envVar, "valueFrom")
-			envVar["value"] = sealedSecret
-			return nil
+			env, ok := c["env"].([]interface{})
+			if !ok {
+				continue
+			}
+
+			for _, e := range env {
+				envVar, ok := e.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				envName, _ := envVar["name"].(string)
+				if envName != envVarName {
+					continue
+				}
+
+				delete(envVar, "valueFrom")
+				envVar["value"] = sealedSecret
+				return nil
+			}
 		}
 	}
 
@@ -1036,74 +1036,70 @@ func (m *Manifest) ConvertEnvFromSecret(containerName, secretName string, sealed
 		return err
 	}
 
-	containers, ok := podSpec["containers"].([]interface{})
-	if !ok {
-		return fmt.Errorf("no containers found in spec")
-	}
-
-	// Find the container
-	for _, container := range containers {
-		c, ok := container.(map[string]interface{})
+	for _, containerKey := range []string{"containers", "initContainers"} {
+		containers, ok := podSpec[containerKey].([]interface{})
 		if !ok {
 			continue
 		}
 
-		// Check if this is the target container
-		name, _ := c["name"].(string)
-		if containerName != "" && name != containerName {
-			continue
-		}
-
-		// Remove envFrom entry for this secret
-		envFrom, ok := c["envFrom"].([]interface{})
-		if ok {
-			var newEnvFrom []interface{}
-			for _, ef := range envFrom {
-				efMap, ok := ef.(map[string]interface{})
-				if !ok {
-					newEnvFrom = append(newEnvFrom, ef)
-					continue
-				}
-
-				secretRef, ok := efMap["secretRef"].(map[string]interface{})
-				if !ok {
-					newEnvFrom = append(newEnvFrom, ef)
-					continue
-				}
-
-				refName, _ := secretRef["name"].(string)
-				if refName != secretName {
-					newEnvFrom = append(newEnvFrom, ef)
-				}
-				// Skip this secretRef (we're converting it to env vars)
+		for _, container := range containers {
+			c, ok := container.(map[string]interface{})
+			if !ok {
+				continue
 			}
 
-			if len(newEnvFrom) > 0 {
-				c["envFrom"] = newEnvFrom
+			name, _ := c["name"].(string)
+			if containerName != "" && name != containerName {
+				continue
+			}
+
+			envFrom, ok := c["envFrom"].([]interface{})
+			if ok {
+				var newEnvFrom []interface{}
+				for _, ef := range envFrom {
+					efMap, ok := ef.(map[string]interface{})
+					if !ok {
+						newEnvFrom = append(newEnvFrom, ef)
+						continue
+					}
+
+					secretRef, ok := efMap["secretRef"].(map[string]interface{})
+					if !ok {
+						newEnvFrom = append(newEnvFrom, ef)
+						continue
+					}
+
+					refName, _ := secretRef["name"].(string)
+					if refName != secretName {
+						newEnvFrom = append(newEnvFrom, ef)
+					}
+				}
+
+				if len(newEnvFrom) > 0 {
+					c["envFrom"] = newEnvFrom
+				} else {
+					delete(c, "envFrom")
+				}
+			}
+
+			var env []interface{}
+			if existing, ok := c["env"].([]interface{}); ok {
+				env = existing
 			} else {
-				delete(c, "envFrom")
+				env = []interface{}{}
 			}
-		}
 
-		// Add individual env variables
-		var env []interface{}
-		if existing, ok := c["env"].([]interface{}); ok {
-			env = existing
-		} else {
-			env = []interface{}{}
-		}
-
-		// Add each sealed secret as an env var
-		for key, sealedSecret := range sealedSecretsMap {
-			envVar := map[string]interface{}{
-				"name":  key,
-				"value": sealedSecret,
+			for key, sealedSecret := range sealedSecretsMap {
+				envVar := map[string]interface{}{
+					"name":  key,
+					"value": sealedSecret,
+				}
+				env = append(env, envVar)
 			}
-			env = append(env, envVar)
-		}
 
-		c["env"] = env
-		return nil
+			c["env"] = env
+			return nil
+		}
 	}
 
 	return fmt.Errorf("container %s not found", containerName)

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -62,17 +62,19 @@ func DetectSecrets(manifestData map[string]interface{}) ([]SecretReference, erro
 	// Map to collect all secrets: secretName -> SecretReference
 	secretsMap := make(map[string]*SecretReference)
 
-	// 1. Detect secrets from containers
-	if containers, ok := podSpec["containers"].([]interface{}); ok {
-		for _, container := range containers {
-			if c, ok := container.(map[string]interface{}); ok {
-				containerName := getContainerName(c)
+	// 1. Detect secrets from containers and initContainers
+	for _, containerKey := range []string{"containers", "initContainers"} {
+		if containers, ok := podSpec[containerKey].([]interface{}); ok {
+			for _, container := range containers {
+				if c, ok := container.(map[string]interface{}); ok {
+					containerName := getContainerName(c)
 
-				// Detect env variable secrets
-				detectEnvSecrets(c, containerName, namespace, secretsMap)
+					// Detect env variable secrets
+					detectEnvSecrets(c, containerName, namespace, secretsMap)
 
-				// Detect envFrom secrets
-				detectEnvFromSecrets(c, containerName, namespace, secretsMap)
+					// Detect envFrom secrets
+					detectEnvFromSecrets(c, containerName, namespace, secretsMap)
+				}
 			}
 		}
 	}
@@ -81,11 +83,13 @@ func DetectSecrets(manifestData map[string]interface{}) ([]SecretReference, erro
 	detectVolumeSecrets(podSpec, namespace, secretsMap)
 
 	// 3. Find mount paths for volume secrets
-	if containers, ok := podSpec["containers"].([]interface{}); ok {
-		for _, container := range containers {
-			if c, ok := container.(map[string]interface{}); ok {
-				containerName := getContainerName(c)
-				addVolumeMountPaths(c, containerName, secretsMap)
+	for _, containerKey := range []string{"containers", "initContainers"} {
+		if containers, ok := podSpec[containerKey].([]interface{}); ok {
+			for _, container := range containers {
+				if c, ok := container.(map[string]interface{}); ok {
+					containerName := getContainerName(c)
+					addVolumeMountPaths(c, containerName, secretsMap)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
DetectSecrets, ConvertEnvSecretToSealed, ConvertEnvFromSecret, and ReplaceSecretName only iterated over podSpec["containers"], so secrets referenced exclusively in initContainers were silently ignored and no sealed secret file was generated.