### PR TITLE
init: add trustee-ca-cert flag

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,6 +59,7 @@ func init() {
 	initCmd.Flags().Bool("enable-sidecar", false, "Enable sidecar and generate client CA and client certificates")
 	initCmd.Flags().Bool("upload-client-ca", false, "Upload client CA to Trustee KBS")
 	initCmd.Flags().String("cert-dir", "", "Default directory to store/load sidecar certificates and keys (default: $HOME/.kube/coco-sidecar)")
+	initCmd.Flags().String("trustee-ca-cert", "", "Path to the Trustee CA certificate file")
 }
 
 func runInit(cmd *cobra.Command, _ []string) error {
@@ -71,6 +72,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	enableSidecar, _ := cmd.Flags().GetBool("enable-sidecar")
 	uploadClientCA, _ := cmd.Flags().GetBool("upload-client-ca")
 	certDir, _ := cmd.Flags().GetString("cert-dir")
+	trusteeCACert, _ := cmd.Flags().GetString("trustee-ca-cert")
 
 	// Get default config path if not specified
 	if outputPath == "" {
@@ -103,6 +105,10 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to get cert directory: %w", err)
 	}
 	cfg.Sidecar.CertDir = certDir
+
+	if trusteeCACert != "" {
+		cfg.TrusteeCACert = trusteeCACert
+	}
 
 	// Handle Trustee setup
 	trusteeDeployed, actualNamespace, err := handleTrusteeSetup(cmd, cfg, interactive, skipTrusteeDeploy, trusteeNamespace, trusteeURL)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -9,7 +9,26 @@ import (
 	"testing"
 
 	"github.com/confidential-devhub/cococtl/pkg/config"
+	"github.com/spf13/cobra"
 )
+
+func newTestInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "init",
+		RunE: runInit,
+	}
+	cmd.Flags().StringP("output", "o", "", "Output path for config file")
+	cmd.Flags().BoolP("interactive", "i", false, "Enable interactive prompts")
+	cmd.Flags().Bool("skip-trustee-deploy", false, "Skip Trustee deployment")
+	cmd.Flags().String("trustee-namespace", "", "Namespace for Trustee deployment")
+	cmd.Flags().String("trustee-url", "", "Trustee server URL")
+	cmd.Flags().String("runtime-class", "", "RuntimeClass to use")
+	cmd.Flags().Bool("enable-sidecar", false, "Enable sidecar")
+	cmd.Flags().Bool("upload-client-ca", false, "Upload client CA to Trustee KBS")
+	cmd.Flags().String("cert-dir", "", "Directory for sidecar certificates")
+	cmd.Flags().String("trustee-ca-cert", "", "Path to Trustee CA certificate file")
+	return cmd
+}
 
 func withStdin(t *testing.T, input string, fn func()) {
 	t.Helper()
@@ -88,7 +107,7 @@ func TestInitCommand_WithRuntimeClassFlag(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "test-config.toml")
 
 	// Create and execute init command with flags
-	cmd := initCmd
+	cmd := newTestInitCmd()
 	if err := cmd.Flags().Set("output", configPath); err != nil {
 		t.Fatalf("Failed to set output flag: %v", err)
 	}
@@ -128,7 +147,7 @@ func TestInitCommand_WithoutRuntimeClassFlag(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "test-config.toml")
 
 	// Create and execute init command without runtime-class flag
-	cmd := initCmd
+	cmd := newTestInitCmd()
 	if err := cmd.Flags().Set("output", configPath); err != nil {
 		t.Fatalf("Failed to set output flag: %v", err)
 	}
@@ -175,7 +194,7 @@ func TestInitCommand_RuntimeClassWithTrusteeURL(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "test-config.toml")
 
 	// Create and execute init command with both flags
-	cmd := initCmd
+	cmd := newTestInitCmd()
 	if err := cmd.Flags().Set("output", configPath); err != nil {
 		t.Fatalf("Failed to set output flag: %v", err)
 	}
@@ -211,7 +230,7 @@ func TestInitCommand_WithTrusteeCACertFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "test-config.toml")
 
-	cmd := initCmd
+	cmd := newTestInitCmd()
 	if err := cmd.Flags().Set("output", configPath); err != nil {
 		t.Fatalf("Failed to set output flag: %v", err)
 	}
@@ -240,10 +259,11 @@ func TestInitCommand_WithTrusteeCACertFlag(t *testing.T) {
 }
 
 // TestInitCommand_WithoutTrusteeCACertFlag tests that trustee_ca_cert remains empty when the flag is unset/cleared
+func TestInitCommand_WithoutTrusteeCACertFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "test-config.toml")
 
-	cmd := initCmd
+	cmd := newTestInitCmd()
 	if err := cmd.Flags().Set("output", configPath); err != nil {
 		t.Fatalf("Failed to set output flag: %v", err)
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -206,6 +206,71 @@ func TestInitCommand_RuntimeClassWithTrusteeURL(t *testing.T) {
 	}
 }
 
+// TestInitCommand_WithTrusteeCACertFlag tests the init command with --trustee-ca-cert flag
+func TestInitCommand_WithTrusteeCACertFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-config.toml")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("output", configPath); err != nil {
+		t.Fatalf("Failed to set output flag: %v", err)
+	}
+	if err := cmd.Flags().Set("trustee-url", "https://trustee.example.com:8080"); err != nil {
+		t.Fatalf("Failed to set trustee-url flag: %v", err)
+	}
+	if err := cmd.Flags().Set("runtime-class", "kata-cc"); err != nil {
+		t.Fatalf("Failed to set runtime-class flag: %v", err)
+	}
+	if err := cmd.Flags().Set("trustee-ca-cert", "/path/to/ca.crt"); err != nil {
+		t.Fatalf("Failed to set trustee-ca-cert flag: %v", err)
+	}
+
+	if err := runInit(cmd, []string{}); err != nil {
+		t.Fatalf("runInit failed: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if cfg.TrusteeCACert != "/path/to/ca.crt" {
+		t.Errorf("TrusteeCACert = %q, want %q", cfg.TrusteeCACert, "/path/to/ca.crt")
+	}
+}
+
+// TestInitCommand_WithoutTrusteeCACertFlag tests that trustee_ca_cert remains empty when the flag is unset/cleared
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-config.toml")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("output", configPath); err != nil {
+		t.Fatalf("Failed to set output flag: %v", err)
+	}
+	if err := cmd.Flags().Set("trustee-url", "https://trustee.example.com:8080"); err != nil {
+		t.Fatalf("Failed to set trustee-url flag: %v", err)
+	}
+	if err := cmd.Flags().Set("runtime-class", "kata-cc"); err != nil {
+		t.Fatalf("Failed to set runtime-class flag: %v", err)
+	}
+	if err := cmd.Flags().Set("trustee-ca-cert", ""); err != nil {
+		t.Fatalf("Failed to set trustee-ca-cert flag: %v", err)
+	}
+
+	if err := runInit(cmd, []string{}); err != nil {
+		t.Fatalf("runInit failed: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if cfg.TrusteeCACert != "" {
+		t.Errorf("TrusteeCACert = %q, want empty string", cfg.TrusteeCACert)
+	}
+}
+
 // TestInitCommand_CertDirWithEnableSidecar tests that --cert-dir is correctly applied
 // together with --enable-sidecar, and that config has the expected certDir after validation.
 // For each (enable-sidecar, cert-dir) combination we build config using the same logic as


### PR DESCRIPTION
This flag allows the user also when not in interactive mode to add the trustee certs, which are essential for initdata.